### PR TITLE
Disable apprunner.AutoScalingConfiguration @aws-cdk/aws-apprunner-alp…

### DIFF
--- a/cdk/lib/speech-web.ts
+++ b/cdk/lib/speech-web.ts
@@ -15,16 +15,16 @@ export class SpeechControlWebConstruct extends Construct {
       directory: path.join(__dirname, "../../speech_control"),
     });
 
-    const autoScalingConfiguration = new apprunner.AutoScalingConfiguration(
-      this,
-      "AutoScalingConfiguration",
-      {
-        autoScalingConfigurationName: "RobotWebAutoScalingConfiguration",
-        maxConcurrency: 100,
-        maxSize: 3,
-        minSize: 1,
-      }
-    );
+    // const autoScalingConfiguration = new apprunner.AutoScalingConfiguration(
+    //   this,
+    //   "AutoScalingConfiguration",
+    //   {
+    //     autoScalingConfigurationName: "RobotWebAutoScalingConfiguration",
+    //     maxConcurrency: 100,
+    //     maxSize: 3,
+    //     minSize: 1,
+    //   }
+    // );
 
     const observabilityConfiguration = new apprunner.ObservabilityConfiguration(
       this,
@@ -48,7 +48,7 @@ export class SpeechControlWebConstruct extends Construct {
       memory: apprunner.Memory.HALF_GB,
       autoDeploymentsEnabled: true,
       observabilityConfiguration,
-      autoScalingConfiguration,
+      // autoScalingConfiguration,
     });
 
     service.addToRolePolicy(

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8,30 +8,30 @@
       "name": "cdk",
       "version": "0.1.0",
       "dependencies": {
-        "@aws-cdk/aws-apigateway": "^1.203.0",
-        "@aws-cdk/aws-apprunner-alpha": "^2.189.1-alpha.0",
-        "@aws-cdk/aws-ecr-assets": "^1.203.0",
-        "@aws-cdk/aws-iam": "^1.203.0",
-        "@aws-cdk/aws-iot": "^1.203.0",
-        "@aws-cdk/aws-lambda": "^1.203.0",
+        "@aws-cdk/aws-apigateway": "^1.204.0",
+        "@aws-cdk/aws-apprunner-alpha": "^2.192.0-alpha.0",
+        "@aws-cdk/aws-ecr-assets": "^1.204.0",
+        "@aws-cdk/aws-iam": "^1.204.0",
+        "@aws-cdk/aws-iot": "^1.204.0",
+        "@aws-cdk/aws-lambda": "^1.204.0",
         "@aws-cdk/aws-lambda-python-alpha": "^2.192.0-alpha.0",
-        "@aws-cdk/aws-s3": "^1.203.0",
-        "@aws-cdk/aws-s3-deployment": "^1.203.0",
-        "aws-cdk-lib": "^2.189.1",
-        "cdk-iot-core-certificates-v3": "^0.0.13",
-        "constructs": "^10.0.0"
+        "@aws-cdk/aws-s3": "^1.204.0",
+        "@aws-cdk/aws-s3-deployment": "^1.204.0",
+        "aws-cdk-lib": "^2.192.0",
+        "cdk-iot-core-certificates-v3": "^0.0.14",
+        "constructs": "^10.4.2"
       },
       "bin": {
         "cdk": "bin/cdk.js"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
-        "@types/node": "22.7.9",
-        "aws-cdk": "2.1007.0",
+        "@types/node": "22.15.3",
+        "aws-cdk": "2.1012.0",
         "jest": "^29.7.0",
-        "ts-jest": "^29.2.5",
+        "ts-jest": "^29.3.2",
         "ts-node": "^10.9.2",
-        "typescript": "~5.6.3"
+        "typescript": "~5.8.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -61,21 +61,22 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/assets": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.203.0.tgz",
-      "integrity": "sha512-aEexr1PEZPqTcBXiKLwmiWYtpoC6vPpsGAqe39U6lovXP675qO6/VTpE26AUtS0sDkuhCBnXDQR5H49e0+A+jQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.204.0.tgz",
+      "integrity": "sha512-rY9YHZ3gUWr+dLwTwSUWYbIfk/AXy4JZRkhLbunrtzjQhH+QMm/2IWIebfBGu+A5AlVRaFbRLonReuGP5WZoUQ==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -89,19 +90,20 @@
       }
     },
     "node_modules/@aws-cdk/aws-acmpca": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-acmpca/-/aws-acmpca-1.203.0.tgz",
-      "integrity": "sha512-0+7de1E0JxTjPe8pm73Io3WAEC9pvEjdKmNYwXApYCslqlFqBOuHjU9pQh++6cYcUWCMmav1iwM9zqCB6ZVRSQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-acmpca/-/aws-acmpca-1.204.0.tgz",
+      "integrity": "sha512-2zyuQZwynwkz2qiuFDp088tglWXKX3q7saWRDqeuq2n2HE6PGuQRjd4zjl9nDGUVxQYtzzXyEuPyaEta8fg9lQ==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -115,43 +117,44 @@
       }
     },
     "node_modules/@aws-cdk/aws-apigateway": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.203.0.tgz",
-      "integrity": "sha512-nT5fisO+vznBLygjrDP3/nZXvgclW6prColqFefonutGf42nXyy21V84IcwOJNwSu1FkARb3tfMX7XbPoI47sQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.204.0.tgz",
+      "integrity": "sha512-uVK309Ltdq/Q0w0tREtIIJYKAeevKwU/oqVMy+PKis1+bSEesN64hIPAd+qqBuChrzCdhEDtY9oiKGOTvM0Alg==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-certificatemanager": "1.203.0",
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-cognito": "1.203.0",
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/aws-logs": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/aws-s3-assets": "1.203.0",
-        "@aws-cdk/aws-stepfunctions": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/aws-certificatemanager": "1.204.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-cognito": "1.204.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/aws-logs": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/aws-s3-assets": "1.204.0",
+        "@aws-cdk/aws-stepfunctions": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-certificatemanager": "1.203.0",
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-cognito": "1.203.0",
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/aws-logs": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/aws-s3-assets": "1.203.0",
-        "@aws-cdk/aws-stepfunctions": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/aws-certificatemanager": "1.204.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-cognito": "1.204.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/aws-logs": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/aws-s3-assets": "1.204.0",
+        "@aws-cdk/aws-stepfunctions": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -165,25 +168,26 @@
       }
     },
     "node_modules/@aws-cdk/aws-applicationautoscaling": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.203.0.tgz",
-      "integrity": "sha512-tz/BzZ++hd+T5s4AQo4l7fKaK6+xeGEbR7fGulgz8xByW5V46/krXvpTWVvM7VV2WSigVx1QeS9vcT3MOdsYBQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.204.0.tgz",
+      "integrity": "sha512-sEe2NODKUowJx2guM2SPfs/20gGdBq1C09M32b8c1im7K+PqQkHkE156nyz5Ml0hpsNeCZlRS17oKZ042aZevQ==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-autoscaling-common": "1.203.0",
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-autoscaling-common": "1.204.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-autoscaling-common": "1.203.0",
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-autoscaling-common": "1.204.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -197,34 +201,35 @@
       }
     },
     "node_modules/@aws-cdk/aws-apprunner-alpha": {
-      "version": "2.189.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apprunner-alpha/-/aws-apprunner-alpha-2.189.1-alpha.0.tgz",
-      "integrity": "sha512-hSgIK+Ed5VKSjAkg1C4DRj/RbaMaprGtIfZTK5MMoZKjJDuWQ10Tksl9zx2VlclXByQsPb7ra3gIEdD3zdYMag==",
+      "version": "2.192.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apprunner-alpha/-/aws-apprunner-alpha-2.192.0-alpha.0.tgz",
+      "integrity": "sha512-OeN/+kuUyKdii6v3l99A9cmB+oTk6jWcvsuG8nbQ2+sxHd+0zCmgx1YOIizsq+7cOcoCTVN77GiFhRlJ7k400Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.189.1",
+        "aws-cdk-lib": "^2.192.0",
         "constructs": "^10.0.0"
       }
     },
     "node_modules/@aws-cdk/aws-autoscaling-common": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.203.0.tgz",
-      "integrity": "sha512-ET3whArynAzRMxrnlkgAdWWzdaRg2QJWcepjSr615pwF0cOFjTW2scpPWIpcaugN2z+wFPlylP5zloA16FM0Tg==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.204.0.tgz",
+      "integrity": "sha512-P+PwbTaj28Eg9+/U9ZTXTh1gA7L9Z45GL+9xcEZvEqAkJt9MNgzZICavVZu1sMD74foK1r1ZOBXTsqV6wEiltQ==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -238,29 +243,30 @@
       }
     },
     "node_modules/@aws-cdk/aws-certificatemanager": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.203.0.tgz",
-      "integrity": "sha512-P/xgE5oF623T9NIlTRfTwX6zR41ae2C+YAVOpGlI4X8ZnjB219LGZd7VhAIu6A6qv38ZQE2erYaXHe39nIFEFg==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.204.0.tgz",
+      "integrity": "sha512-ZLykfAOb5Zbg/MFtzA+eHhMAK1xL32+oHKSK6tAYrgvv2aS42wJE4zSBV6jGCjnCkhcliUd5pwnACEl3ib0KLw==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-acmpca": "1.203.0",
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/aws-route53": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-acmpca": "1.204.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/aws-route53": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-acmpca": "1.203.0",
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/aws-route53": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-acmpca": "1.204.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/aws-route53": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -274,29 +280,30 @@
       }
     },
     "node_modules/@aws-cdk/aws-cloudformation": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.203.0.tgz",
-      "integrity": "sha512-vwNrk5KT0TgIKy+hinjWu/CBEet394mK8o2eFzQG5G82An0O3n/ILdaBrXZut0tyHxJSYQ90+Zaor6Ndld49jA==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.204.0.tgz",
+      "integrity": "sha512-9PkZa9mKLneB0My8wJC7lLZmPJsnOxNYy57ZZlRCQhK0eO6Jc9eVqrI29537W+3ireaEjCLEitkb8NO1FN/kQA==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/aws-sns": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/aws-sns": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/aws-sns": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/aws-sns": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -310,37 +317,38 @@
       }
     },
     "node_modules/@aws-cdk/aws-cloudfront": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.203.0.tgz",
-      "integrity": "sha512-BdSCRoQ0CWT8U5Mhog80+sENG8bReXqhyzu8fyRLwT4EvCNmDEYVjotG7xbzgobRYKL0zhMMvNAtVZ3I1iw0fQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.204.0.tgz",
+      "integrity": "sha512-bgqGsImVjFQJihDvLg0hWRtmq2b+HVj94Fngz/zo4PsB5kTt1QZvHOk2HNBkozNhDK8LXysHtdKvmzpaK29TJQ==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-certificatemanager": "1.203.0",
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/aws-ssm": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/aws-certificatemanager": "1.204.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/aws-ssm": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-certificatemanager": "1.203.0",
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/aws-ssm": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/aws-certificatemanager": "1.204.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/aws-ssm": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -354,21 +362,22 @@
       }
     },
     "node_modules/@aws-cdk/aws-cloudwatch": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.203.0.tgz",
-      "integrity": "sha512-RJfUHAtCPefcgWlH6Nqcv0f1svPfxbESUC52tK6yKqhmzo+57ePLkONsn88x22TuWo/hXOpjxYqrUECr0S5YqA==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.204.0.tgz",
+      "integrity": "sha512-ADT2D+4FtB9Zcy/TlF2tswQmjmrPVgORYTkznQQ2SniCODHWzz558+G1RV+IVvWRdH7nYQtV0UEuGZKpffWh2w==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -382,21 +391,22 @@
       }
     },
     "node_modules/@aws-cdk/aws-codeguruprofiler": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.203.0.tgz",
-      "integrity": "sha512-Tl9DGRY/BN615J8H4SUQxQ0Zb2TzkaBYHFx4F1lt4NYdWHYh6oALxLEBSkXD5txPvvtH4MouDENuqMBV/fZI3w==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.204.0.tgz",
+      "integrity": "sha512-IrgY4SmVf9p5POfHm8BsPzaAO5lQTG7nhb5qN5AzS6zKCTuEjjTNHjx1TOfPV12mMIDAIVsK91mjDlAR88Mjbg==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -410,19 +420,20 @@
       }
     },
     "node_modules/@aws-cdk/aws-codestarnotifications": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.203.0.tgz",
-      "integrity": "sha512-Qd3iJiFx5Nt+rZRNnmMUmknNetq4069pUhOTv0NTxB+ZmWQ1leQ4iSrhQ5YOANWBK0+EtPMz9YBjKjE4zBPf+Q==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.204.0.tgz",
+      "integrity": "sha512-t//hSpC5/uVW2321YlbGabNVzhWayvqz+xSnagADGcT9qiq3KQR/uUlrgpHv1/eHRMk7EMrY9prlXeZpfzZ+cw==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -436,20 +447,21 @@
       }
     },
     "node_modules/@aws-cdk/aws-cognito": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.203.0.tgz",
-      "integrity": "sha512-8+Fih6EQkVFN6HFW2jW61sOLsrk1WCKgmtJcJphP5BONWprhzSX2iCexCxlwMV4OpUkiADBmr8DIYyFy08X5jQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.204.0.tgz",
+      "integrity": "sha512-7QIbExW9dn1fktpDOh2nMHmor2S3uuHtIX5y33lc9OKg3xUuYw4AZ67MKapunN7QUBlffTlNzoUqlHoNSab+Zg==",
       "bundleDependencies": [
         "punycode"
       ],
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-certificatemanager": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/custom-resources": "1.203.0",
+        "@aws-cdk/aws-certificatemanager": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/custom-resources": "1.204.0",
         "constructs": "^3.3.69",
         "punycode": "^2.3.0"
       },
@@ -457,12 +469,12 @@
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-certificatemanager": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/custom-resources": "1.203.0",
+        "@aws-cdk/aws-certificatemanager": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/custom-resources": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -484,50 +496,52 @@
       }
     },
     "node_modules/@aws-cdk/aws-ec2": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.203.0.tgz",
-      "integrity": "sha512-6Q/kvAKsprESeGCYMYS9KiChDyhzMk6NerSreVD83UbcvUJU9EjGUJF+HJfRQXn66YjdOsXKcm89Ni31ftP5PQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.204.0.tgz",
+      "integrity": "sha512-SoqZEgzdfPW0aa+FQ0CjzbDG+X+sDu6/BnLL2O10lxpa+9Dc1iyArAqNKFJG5KXGJe9ibvQXyNQqEjeGRFc22Q==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/aws-logs": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/aws-s3-assets": "1.203.0",
-        "@aws-cdk/aws-ssm": "1.203.0",
-        "@aws-cdk/cloud-assembly-schema": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
-        "@aws-cdk/region-info": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/aws-logs": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/aws-s3-assets": "1.204.0",
+        "@aws-cdk/aws-ssm": "1.204.0",
+        "@aws-cdk/cloud-assembly-schema": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
+        "@aws-cdk/region-info": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/aws-logs": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/aws-s3-assets": "1.203.0",
-        "@aws-cdk/aws-ssm": "1.203.0",
-        "@aws-cdk/cloud-assembly-schema": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
-        "@aws-cdk/region-info": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/aws-logs": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/aws-s3-assets": "1.204.0",
+        "@aws-cdk/aws-ssm": "1.204.0",
+        "@aws-cdk/cloud-assembly-schema": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
+        "@aws-cdk/region-info": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
     "node_modules/@aws-cdk/aws-ec2/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.203.0.tgz",
-      "integrity": "sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.204.0.tgz",
+      "integrity": "sha512-DMNSR4DNKMNNfhOq1UizwZvesOKdhk3R3gRigrvWBHIkHMQg+W6aZFl7WZLKSBkChAXhIsH///psjhDQ20gl1w==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.4.1",
@@ -585,52 +599,54 @@
       }
     },
     "node_modules/@aws-cdk/aws-ecr": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.203.0.tgz",
-      "integrity": "sha512-pMijGTZzncb10zJLuqDzFtHpVxpK2dQdD/1Md7FYF1Mm7/r2CFx4Q2H3f1fOi4sBXk3ftypV8X7HFzIrWPwCSg==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.204.0.tgz",
+      "integrity": "sha512-oCts9e+ackWoFHeyn/3oKm3X1lSizleWNNXHp5WGM38lpNVrtCLMKSShu5iXJBhqRH2Mz1AcA4fDMWhe8DvJFA==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-events": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-events": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-events": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-events": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
     "node_modules/@aws-cdk/aws-ecr-assets": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.203.0.tgz",
-      "integrity": "sha512-wPAjllyLs+TvdakhwATjIyc5mBuNJFurPM2S1mo7YC4fURp2NOb9vHpIFgV9ZC+r8xadBFWt13de72cyl+h2iw==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.204.0.tgz",
+      "integrity": "sha512-2GHD3pZdDoPxq3HhD4czANuI7TMoxpjszbzsQAc2wbdMX1j+K4vIL+PBpj3altfscPqcvy1v70lBjbG5rcBIkQ==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/assets": "1.203.0",
-        "@aws-cdk/aws-ecr": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/assets": "1.204.0",
+        "@aws-cdk/aws-ecr": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/assets": "1.203.0",
-        "@aws-cdk/aws-ecr": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/assets": "1.204.0",
+        "@aws-cdk/aws-ecr": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -653,40 +669,42 @@
       }
     },
     "node_modules/@aws-cdk/aws-efs": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.203.0.tgz",
-      "integrity": "sha512-JYy8N7GwKCXjFpsBZZqy9VbS/zJGDSq8etXAvBsrscDveDzzQr4/6CiXYU70aL5lLV34ex07A5lKBmII9cqq0Q==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.204.0.tgz",
+      "integrity": "sha512-FB6nHgCuzYF5K9ywqYPEPjL2G1ATLIR9dJp1p4ydcEUuXDb4KSEVN4Bgx+q1e7EkWGIq+9glr+ckheEcTvETgw==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/cloud-assembly-schema": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/cloud-assembly-schema": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/cloud-assembly-schema": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/cloud-assembly-schema": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
     "node_modules/@aws-cdk/aws-efs/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.203.0.tgz",
-      "integrity": "sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.204.0.tgz",
+      "integrity": "sha512-DMNSR4DNKMNNfhOq1UizwZvesOKdhk3R3gRigrvWBHIkHMQg+W6aZFl7WZLKSBkChAXhIsH///psjhDQ20gl1w==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.4.1",
@@ -744,50 +762,52 @@
       }
     },
     "node_modules/@aws-cdk/aws-elasticloadbalancingv2": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.203.0.tgz",
-      "integrity": "sha512-Auws0z0InGeNOwrap3MhVIzdZYJH4+V9r7cmYR8MGWgWE0x1HQqKd5ZqzBa6yHeqglnAK44fk9PbSyjGlPYuuA==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.204.0.tgz",
+      "integrity": "sha512-/43kzUTU3w9jimPuD5QZxoBN74+9QnOdhAcqIMVCFLPMkVLAxx3vg5g5MWWG+3j6rUoSecrtrP1AP7thZuo5wA==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-certificatemanager": "1.203.0",
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/aws-route53": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/cloud-assembly-schema": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
-        "@aws-cdk/region-info": "1.203.0",
+        "@aws-cdk/aws-certificatemanager": "1.204.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/aws-route53": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/cloud-assembly-schema": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
+        "@aws-cdk/region-info": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-certificatemanager": "1.203.0",
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/aws-route53": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/cloud-assembly-schema": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
-        "@aws-cdk/region-info": "1.203.0",
+        "@aws-cdk/aws-certificatemanager": "1.204.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/aws-route53": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/cloud-assembly-schema": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
+        "@aws-cdk/region-info": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
     "node_modules/@aws-cdk/aws-elasticloadbalancingv2/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.203.0.tgz",
-      "integrity": "sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.204.0.tgz",
+      "integrity": "sha512-DMNSR4DNKMNNfhOq1UizwZvesOKdhk3R3gRigrvWBHIkHMQg+W6aZFl7WZLKSBkChAXhIsH///psjhDQ20gl1w==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.4.1",
@@ -845,21 +865,22 @@
       }
     },
     "node_modules/@aws-cdk/aws-events": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.203.0.tgz",
-      "integrity": "sha512-LYjKGqqosXG3HLAmvSAS/N5OSxH0uqHmDlisapwl4kEBPfSOvzzVF9TTuMulDYfSBV0Esspb3RIkXc/ja7f9JQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.204.0.tgz",
+      "integrity": "sha512-KnfUmtv+4RhydD9+5CHFxNJxtgn7+Xftwfwg1G7qV/tWYPFHcNIvhlSOgwDrQPa+pTo1MmkiUN0lAR0G8B/cbw==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -873,22 +894,23 @@
       }
     },
     "node_modules/@aws-cdk/aws-iam": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.203.0.tgz",
-      "integrity": "sha512-8qXLtOzkaLlk7WlssocExMYruOb59irhspTvHvf/kpcMBmWQoyNRC80Ab3QtXkZNBppfrMkROGZvqzW2GlxAwQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.204.0.tgz",
+      "integrity": "sha512-Fh2egW3v/uDdw3m4jvcupS7COL/+sJl2NHjz9l298ddyMxqDwJD2NQwE8mvgPLK4rDtAtDnE0c8RS6d+NWiC+w==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
-        "@aws-cdk/region-info": "1.203.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
+        "@aws-cdk/region-info": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/region-info": "1.203.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/region-info": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -902,19 +924,20 @@
       }
     },
     "node_modules/@aws-cdk/aws-iot": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iot/-/aws-iot-1.203.0.tgz",
-      "integrity": "sha512-8kXQAeGNTEWM0IKLwZPj7icZiDNYKgb45DHGIbsBfC66Z5m+lUVSTMZoiqsW6EF7T3YZ98d7CdZ53Dy23cKtGA==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iot/-/aws-iot-1.204.0.tgz",
+      "integrity": "sha512-XhGxxXUOmOqTng9Ljtvo5C6BGyMFpCGXJOluVlAbqRg5iQczNedslIkXf5iAuQ6dAkRWFJjGVoWnBbaL3nji4A==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -928,36 +951,38 @@
       }
     },
     "node_modules/@aws-cdk/aws-kms": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.203.0.tgz",
-      "integrity": "sha512-TlG5Td7pRrgo5xta0ePIp6x6+4uq0P+1K3tQtpjEFbD2E21krujXdWNdHmuvRoNsY5NbLhOCF5g6PNCdJdvLJA==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.204.0.tgz",
+      "integrity": "sha512-iryZQ428L1VUVQ0zE96XTWWX7ANVtDrb6x+ZXXLTVUEPgjEd/W6zlcp++Qi0A3a9HLNd4PbEhK9rs0UKNTylzw==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/cloud-assembly-schema": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/cloud-assembly-schema": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/cloud-assembly-schema": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/cloud-assembly-schema": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
     "node_modules/@aws-cdk/aws-kms/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.203.0.tgz",
-      "integrity": "sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.204.0.tgz",
+      "integrity": "sha512-DMNSR4DNKMNNfhOq1UizwZvesOKdhk3R3gRigrvWBHIkHMQg+W6aZFl7WZLKSBkChAXhIsH///psjhDQ20gl1w==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.4.1",
@@ -1015,55 +1040,56 @@
       }
     },
     "node_modules/@aws-cdk/aws-lambda": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.203.0.tgz",
-      "integrity": "sha512-O88yvNpxi4tcizHhwRkGfEBg+WDoagxgwr2TUNFWkKQVEaL/by9BeZk84LNXLC6OO5WrnC+0qgSz1KHyDXMrqw==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.204.0.tgz",
+      "integrity": "sha512-r0XXovrLAx8Q8Fz915SwzyQM/KLhEB6YCp3CsWliFGSOHEjRP8yX8UZdEJqe5kYD7Th9JAhUVzKgyv20P7g5Tg==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-applicationautoscaling": "1.203.0",
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-codeguruprofiler": "1.203.0",
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-ecr": "1.203.0",
-        "@aws-cdk/aws-ecr-assets": "1.203.0",
-        "@aws-cdk/aws-efs": "1.203.0",
-        "@aws-cdk/aws-events": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/aws-logs": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/aws-s3-assets": "1.203.0",
-        "@aws-cdk/aws-signer": "1.203.0",
-        "@aws-cdk/aws-sns": "1.203.0",
-        "@aws-cdk/aws-sqs": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
-        "@aws-cdk/region-info": "1.203.0",
+        "@aws-cdk/aws-applicationautoscaling": "1.204.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-codeguruprofiler": "1.204.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-ecr": "1.204.0",
+        "@aws-cdk/aws-ecr-assets": "1.204.0",
+        "@aws-cdk/aws-efs": "1.204.0",
+        "@aws-cdk/aws-events": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/aws-logs": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/aws-s3-assets": "1.204.0",
+        "@aws-cdk/aws-signer": "1.204.0",
+        "@aws-cdk/aws-sns": "1.204.0",
+        "@aws-cdk/aws-sqs": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
+        "@aws-cdk/region-info": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-applicationautoscaling": "1.203.0",
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-codeguruprofiler": "1.203.0",
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-ecr": "1.203.0",
-        "@aws-cdk/aws-ecr-assets": "1.203.0",
-        "@aws-cdk/aws-efs": "1.203.0",
-        "@aws-cdk/aws-events": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/aws-logs": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/aws-s3-assets": "1.203.0",
-        "@aws-cdk/aws-signer": "1.203.0",
-        "@aws-cdk/aws-sns": "1.203.0",
-        "@aws-cdk/aws-sqs": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
-        "@aws-cdk/region-info": "1.203.0",
+        "@aws-cdk/aws-applicationautoscaling": "1.204.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-codeguruprofiler": "1.204.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-ecr": "1.204.0",
+        "@aws-cdk/aws-ecr-assets": "1.204.0",
+        "@aws-cdk/aws-efs": "1.204.0",
+        "@aws-cdk/aws-events": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/aws-logs": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/aws-s3-assets": "1.204.0",
+        "@aws-cdk/aws-signer": "1.204.0",
+        "@aws-cdk/aws-sns": "1.204.0",
+        "@aws-cdk/aws-sqs": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
+        "@aws-cdk/region-info": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -1090,29 +1116,30 @@
       }
     },
     "node_modules/@aws-cdk/aws-logs": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.203.0.tgz",
-      "integrity": "sha512-I5/0+NuPdTRSq0cK8W1w8hHyGGj4mqTXFou0sHed3BUN4zYim2cB88uosOVMOhkpGRr19+FEwEThvyntRLcTOQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.204.0.tgz",
+      "integrity": "sha512-PuHsDSkX6JFBgldxViGw91eFLageJ2cX89/RyLbWaJJUV4tlUKXSmmkVgOaBmvil0QKuGqbOzLXcXCoIK9Sg3A==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/aws-s3-assets": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/aws-s3-assets": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/aws-s3-assets": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/aws-s3-assets": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -1126,40 +1153,42 @@
       }
     },
     "node_modules/@aws-cdk/aws-route53": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.203.0.tgz",
-      "integrity": "sha512-u2lvS15JtZURBxK8SCMBcUaNOiBhHfWThk6wm7GfkoaSFsgdDnM/siePEHv8aau1PkRnXX4esy6RQGwIUohyfw==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.204.0.tgz",
+      "integrity": "sha512-wQpGUXqc2y7yJFTipfuVxWy/VGeshyGlfGl4evusQK9Md0DMpVmG8kRgazLk1myqUSNSfi643UwvDJqNbYmdnA==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-logs": "1.203.0",
-        "@aws-cdk/cloud-assembly-schema": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/custom-resources": "1.203.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-logs": "1.204.0",
+        "@aws-cdk/cloud-assembly-schema": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/custom-resources": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-logs": "1.203.0",
-        "@aws-cdk/cloud-assembly-schema": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/custom-resources": "1.203.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-logs": "1.204.0",
+        "@aws-cdk/cloud-assembly-schema": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/custom-resources": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
     "node_modules/@aws-cdk/aws-route53/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.203.0.tgz",
-      "integrity": "sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.204.0.tgz",
+      "integrity": "sha512-DMNSR4DNKMNNfhOq1UizwZvesOKdhk3R3gRigrvWBHIkHMQg+W6aZFl7WZLKSBkChAXhIsH///psjhDQ20gl1w==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.4.1",
@@ -1217,54 +1246,56 @@
       }
     },
     "node_modules/@aws-cdk/aws-s3": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.203.0.tgz",
-      "integrity": "sha512-xPxCv7l6zh7nGoFwLNzHmP07ULtWx/ubDE6l2ZqkRF4ZHVWoyTk7zVs4Q+BmRM1mUn0yDHyMTKKf887lQu9eVg==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.204.0.tgz",
+      "integrity": "sha512-jsQ4n1L4MdPYDirBoOYgg7yzSk1TaFYo4dnwDlKiLJ5LcHG3Nai1cHb9XQbCy/9KKqbWsbd3WlkH+vcWEl8EUA==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-events": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/aws-events": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-events": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/aws-events": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
     "node_modules/@aws-cdk/aws-s3-assets": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.203.0.tgz",
-      "integrity": "sha512-BXvIWRdHmwNkpDbQXsB0hZWGJ3szB264Dq14CzWu6+6J8beaUNrT+1/z1mglr6S3UraHMsOhhSO48zT9k+MzhA==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.204.0.tgz",
+      "integrity": "sha512-3MQbVZ95wW29Bl63tqu0Bz0td3osLyGg352l5G7Ztf3nK35FpuQlgxO4kcu74+s2sRwdd/R4KFV6eWhhPk+J7g==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/assets": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/assets": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/assets": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
+        "@aws-cdk/assets": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -1278,24 +1309,25 @@
       }
     },
     "node_modules/@aws-cdk/aws-s3-deployment": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-deployment/-/aws-s3-deployment-1.203.0.tgz",
-      "integrity": "sha512-LnxeOjzK1LpaZ+iwTeg9pBPkH9yDp7qKT52PesM/ZFZt+7Dj+EX8onqsgmbBRzV09CgYsG/XFPx06vRJvhNuJg==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-deployment/-/aws-s3-deployment-1.204.0.tgz",
+      "integrity": "sha512-KyJYFqSXoEkHbZgRRzzJ58Yalw6KRM4p7Td+b65blWFAlM/1w+3hDZTTYWM31JYkfkJmdsx2JqP0AoG0KXkY7g==",
       "bundleDependencies": [
         "case"
       ],
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-cloudfront": "1.203.0",
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-efs": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/aws-logs": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/aws-s3-assets": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/lambda-layer-awscli": "1.203.0",
+        "@aws-cdk/aws-cloudfront": "1.204.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-efs": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/aws-logs": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/aws-s3-assets": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/lambda-layer-awscli": "1.204.0",
         "case": "1.6.3",
         "constructs": "^3.3.69"
       },
@@ -1303,16 +1335,16 @@
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-cloudfront": "1.203.0",
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-efs": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/aws-logs": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/aws-s3-assets": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
-        "@aws-cdk/lambda-layer-awscli": "1.203.0",
+        "@aws-cdk/aws-cloudfront": "1.204.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-efs": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/aws-logs": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/aws-s3-assets": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
+        "@aws-cdk/lambda-layer-awscli": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -1343,19 +1375,20 @@
       }
     },
     "node_modules/@aws-cdk/aws-signer": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.203.0.tgz",
-      "integrity": "sha512-czHs8DIIA2wxYW2iFTEWAVydFURMvyZO+rtv7V4LXV9G18qRdBVxyx7VU2Lhr8nd5sg+uPV4Vonjt8OvUfO12A==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.204.0.tgz",
+      "integrity": "sha512-AI26FhWF3+f/vDh3mleQa2CXv2/CmSerXgyk4XHMVVTTCjnlYGGmHmGlzYhqOSw6ALpQNdOSw8GVxU/ySpQCaw==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -1369,31 +1402,32 @@
       }
     },
     "node_modules/@aws-cdk/aws-sns": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.203.0.tgz",
-      "integrity": "sha512-9HBgItNq7zM+ElEUEnomHjAgYsZWOjHaafv1x+Gbk/UH4xKzoM7t6kdlRa0qCVeyWhaClGCyRAJtOP42UiGmSg==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.204.0.tgz",
+      "integrity": "sha512-KoWxqKT/dTjt9Pk0a3kJLcd6xZHvrwbZDC0mrLtxdRNhQoHmnURAHW2UqX/lefrCU1GcUFf4L58N9ehBTunAFQ==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-codestarnotifications": "1.203.0",
-        "@aws-cdk/aws-events": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/aws-sqs": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-codestarnotifications": "1.204.0",
+        "@aws-cdk/aws-events": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/aws-sqs": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-codestarnotifications": "1.203.0",
-        "@aws-cdk/aws-events": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/aws-sqs": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-codestarnotifications": "1.204.0",
+        "@aws-cdk/aws-events": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/aws-sqs": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -1407,25 +1441,26 @@
       }
     },
     "node_modules/@aws-cdk/aws-sqs": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.203.0.tgz",
-      "integrity": "sha512-GDSWc/O9HcxjP4pbCYuZjqE2GXymzvv6rM8Q17NtERACpUMf/eAuNITLCulE1Y6ufE9A9/lgkT96I3QLd9HBNw==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.204.0.tgz",
+      "integrity": "sha512-dVzuGMh6d5/X9P9jel1w2Wgdy5MuSE35+eBSFxN+S7oJRoVSARpyKMNYAPMCW+2OJCDw7fIqO1rWbsZBT1Gq8g==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -1439,36 +1474,38 @@
       }
     },
     "node_modules/@aws-cdk/aws-ssm": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.203.0.tgz",
-      "integrity": "sha512-zR/eLVPO+O3MMbnMgWSLybrj7VxIt1d90QPHPZMV92hYdzWDKBfVZ09P82muNILRF+SMcK7TrFLCDi5Nos0S2g==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.204.0.tgz",
+      "integrity": "sha512-yYx7HZ8cWNXDAmX/99WkB477QhLoV2rcB8orei8aj7nRkNq5TMjeox0IJaZVgU+edNEDOi1fVX3flh0SAMiUrg==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/cloud-assembly-schema": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/cloud-assembly-schema": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-kms": "1.203.0",
-        "@aws-cdk/cloud-assembly-schema": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-kms": "1.204.0",
+        "@aws-cdk/cloud-assembly-schema": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
     "node_modules/@aws-cdk/aws-ssm/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.203.0.tgz",
-      "integrity": "sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.204.0.tgz",
+      "integrity": "sha512-DMNSR4DNKMNNfhOq1UizwZvesOKdhk3R3gRigrvWBHIkHMQg+W6aZFl7WZLKSBkChAXhIsH///psjhDQ20gl1w==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.4.1",
@@ -1526,29 +1563,30 @@
       }
     },
     "node_modules/@aws-cdk/aws-stepfunctions": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.203.0.tgz",
-      "integrity": "sha512-2u884kIL+y2HSyo9sh2ovb7iOYyi5Imnu6wdclyQrsM+RgIAw6WAJnOa/HoR7KimlWdfpx7pdV5FQaMu1LRXfQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.204.0.tgz",
+      "integrity": "sha512-S8yuB5GtUajOxUcoMw82HQ+ei1U9uofwENEnEtYTeyqgjpd0FG4XHYoHvBdmgVvEKwpH/XiOePfEHeB8nTXufw==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-events": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-logs": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-events": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-logs": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-cloudwatch": "1.203.0",
-        "@aws-cdk/aws-events": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-logs": "1.203.0",
-        "@aws-cdk/aws-s3": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-cloudwatch": "1.204.0",
+        "@aws-cdk/aws-events": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-logs": "1.204.0",
+        "@aws-cdk/aws-s3": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -1598,20 +1636,21 @@
       }
     },
     "node_modules/@aws-cdk/core": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.203.0.tgz",
-      "integrity": "sha512-3/quPwnGWKHm/Bzna/du5WP5a/Wp/NYqDyL1rJ1A3EPpsRQYywJPj77+M8nG5sD5qNIoFbhN7Q5aee+bcS7GGA==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.204.0.tgz",
+      "integrity": "sha512-yO/flJ9ihpzRhLTEqlbdbuPGtyyghHiiQPkUTLslwUM5vThVTbpgvW4UQHSGqytyst4MYXrN2jQn2RkwIRU57g==",
       "bundleDependencies": [
         "fs-extra",
         "minimatch",
         "@balena/dockerignore",
         "ignore"
       ],
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/cloud-assembly-schema": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
-        "@aws-cdk/region-info": "1.203.0",
+        "@aws-cdk/cloud-assembly-schema": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
+        "@aws-cdk/region-info": "1.204.0",
         "@balena/dockerignore": "^1.0.2",
         "constructs": "^3.3.69",
         "fs-extra": "^9.1.0",
@@ -1622,20 +1661,21 @@
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": "1.203.0",
-        "@aws-cdk/cx-api": "1.203.0",
-        "@aws-cdk/region-info": "1.203.0",
+        "@aws-cdk/cloud-assembly-schema": "1.204.0",
+        "@aws-cdk/cx-api": "1.204.0",
+        "@aws-cdk/region-info": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
     "node_modules/@aws-cdk/core/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.203.0.tgz",
-      "integrity": "sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.204.0.tgz",
+      "integrity": "sha512-DMNSR4DNKMNNfhOq1UizwZvesOKdhk3R3gRigrvWBHIkHMQg+W6aZFl7WZLKSBkChAXhIsH///psjhDQ20gl1w==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.4.1",
@@ -1782,31 +1822,32 @@
       }
     },
     "node_modules/@aws-cdk/custom-resources": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.203.0.tgz",
-      "integrity": "sha512-JpUH3d5gG/2MrWCbnFC96FgRGUqcecY84xZHsfTKUlPQ2bUzElHih2tvbR21DQ5ZIKvFznol3DheduDSD/TgpQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.204.0.tgz",
+      "integrity": "sha512-0w3oi7LnAtMZpf7uUBDH6aT2Oo1EBQrqD+VTvPZDX8PJFAox8ol7buZ9sSTpIXgv9j/GK9yaPTIHt4m8ok9kVQ==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-cloudformation": "1.203.0",
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/aws-logs": "1.203.0",
-        "@aws-cdk/aws-sns": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-cloudformation": "1.204.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/aws-logs": "1.204.0",
+        "@aws-cdk/aws-sns": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-cloudformation": "1.203.0",
-        "@aws-cdk/aws-ec2": "1.203.0",
-        "@aws-cdk/aws-iam": "1.203.0",
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/aws-logs": "1.203.0",
-        "@aws-cdk/aws-sns": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-cloudformation": "1.204.0",
+        "@aws-cdk/aws-ec2": "1.204.0",
+        "@aws-cdk/aws-iam": "1.204.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/aws-logs": "1.204.0",
+        "@aws-cdk/aws-sns": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -1820,32 +1861,34 @@
       }
     },
     "node_modules/@aws-cdk/cx-api": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.203.0.tgz",
-      "integrity": "sha512-W2flnJFGytifPw2ojEsh9l8MAI4UANaUcMKr+qt4eJmFwrtVcS7nasdJQGSatQdxkAwd2pX4x10brAHYoAqjjQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.204.0.tgz",
+      "integrity": "sha512-Juh/jL1kFPD5JcI9Uu6X0mM2L6hBCN5grdjSS40F8dThbH25VPzFBejaKjiy5nP1UZB83X+HW3utYOEi97DqxA==",
       "bundleDependencies": [
         "semver"
       ],
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/cloud-assembly-schema": "1.203.0",
+        "@aws-cdk/cloud-assembly-schema": "1.204.0",
         "semver": "^7.3.8"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": "1.203.0"
+        "@aws-cdk/cloud-assembly-schema": "1.204.0"
       }
     },
     "node_modules/@aws-cdk/cx-api/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.203.0.tgz",
-      "integrity": "sha512-r252InZ8Oh7q7ztriaA3n6F48QOFVfNcT/KO4XOlYyt1xDWRMENDYf+D+DVr6O5klcaa3ivvvDT7DRuW3xdVOQ==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.204.0.tgz",
+      "integrity": "sha512-DMNSR4DNKMNNfhOq1UizwZvesOKdhk3R3gRigrvWBHIkHMQg+W6aZFl7WZLKSBkChAXhIsH///psjhDQ20gl1w==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.4.1",
@@ -1924,21 +1967,22 @@
       "license": "ISC"
     },
     "node_modules/@aws-cdk/lambda-layer-awscli": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-awscli/-/lambda-layer-awscli-1.203.0.tgz",
-      "integrity": "sha512-xA4kO8yl2Q5IjfKvIJvltTXhjEkQVS8lOSsdMIEODkaq7BtttKpxM/dU4LPky5se1nGUttNiJzPKgaXYUHa+4Q==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-awscli/-/lambda-layer-awscli-1.204.0.tgz",
+      "integrity": "sha512-zsZgpkMCNnur1nzbJP5IhBmEPZu1ZbUqruBMDkbpmyF9IQPHoJUa2NwaSYHg6ZZDnuBEZwsJfXckotcQTBktOQ==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       },
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-lambda": "1.203.0",
-        "@aws-cdk/core": "1.203.0",
+        "@aws-cdk/aws-lambda": "1.204.0",
+        "@aws-cdk/core": "1.204.0",
         "constructs": "^3.3.69"
       }
     },
@@ -1952,9 +1996,10 @@
       }
     },
     "node_modules/@aws-cdk/region-info": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.203.0.tgz",
-      "integrity": "sha512-3GzFYrdUO2NGcOrlIJ1TvjRxB0/ntBEyQgwFtVJQSvt3msCznE/w1n6pZS+oDF12NWtIPFbsJ5zTGdJ+PLMJhg==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.204.0.tgz",
+      "integrity": "sha512-lPkYJNoN4Gjlf0Fdfgcd1RTm5RD9qtfaFMwVvTn2KGTr7ZqmFskGQ9FqIcd5vd6GmsbAL8OrFOToLr1AHDuOiQ==",
+      "deprecated": "AWS CDK v1 has reached End-of-Support on 2023-06-01.\nThis package is no longer being updated, and users should migrate to AWS CDK v2.\n\nFor more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 14.15.0"
@@ -2991,13 +3036,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.7.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.9.tgz",
-      "integrity": "sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg==",
+      "version": "22.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
+      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -3131,9 +3176,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1007.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1007.0.tgz",
-      "integrity": "sha512-/UOYOTGWUm+pP9qxg03tID5tL6euC+pb+xo0RBue+xhnUWwj/Bbsw6DbqbpOPMrNzTUxmM723/uMEQmM6S26dw==",
+      "version": "2.1012.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1012.0.tgz",
+      "integrity": "sha512-C6jSWkqP0hkY2Cs300VJHjspmTXDTMfB813kwZvRbd/OsKBfTBJBbYU16VoLAp1LVEOnQMf8otSlaSgzVF0X9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3616,14 +3661,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3748,9 +3791,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-iot-core-certificates-v3": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/cdk-iot-core-certificates-v3/-/cdk-iot-core-certificates-v3-0.0.13.tgz",
-      "integrity": "sha512-xOpj9rrX2nMk25yudzx9WmJJJ1OarfLCAThG/xeLqywcQ56hOdBZAQMTt0RSLpeT/2uKDEXGiZR9p3FAKG1NRg==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/cdk-iot-core-certificates-v3/-/cdk-iot-core-certificates-v3-0.0.14.tgz",
+      "integrity": "sha512-s0haJdXV4/aW0UVuzV/OaP50+XhpbjXuIGlgxQaQY5krKinMPcFkkKDJAYDhkW3+TYm8JZ982qDnlzFDWhyQxg==",
       "bundleDependencies": [
         "@aws-sdk/client-iot",
         "@smithy/smithy-client",
@@ -5599,7 +5642,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/constructs": {
@@ -7113,7 +7155,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -7487,7 +7528,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7861,9 +7901,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7875,9 +7915,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -12,25 +12,25 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/node": "22.7.9",
-    "aws-cdk": "2.1007.0",
+    "@types/node": "22.15.3",
+    "aws-cdk": "2.1012.0",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.5",
+    "ts-jest": "^29.3.2",
     "ts-node": "^10.9.2",
-    "typescript": "~5.6.3"
+    "typescript": "~5.8.3"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "^1.203.0",
-    "@aws-cdk/aws-apprunner-alpha": "^2.189.1-alpha.0",
-    "@aws-cdk/aws-ecr-assets": "^1.203.0",
-    "@aws-cdk/aws-iam": "^1.203.0",
-    "@aws-cdk/aws-iot": "^1.203.0",
-    "@aws-cdk/aws-lambda": "^1.203.0",
+    "@aws-cdk/aws-apigateway": "^1.204.0",
+    "@aws-cdk/aws-apprunner-alpha": "^2.192.0-alpha.0",
+    "@aws-cdk/aws-ecr-assets": "^1.204.0",
+    "@aws-cdk/aws-iam": "^1.204.0",
+    "@aws-cdk/aws-iot": "^1.204.0",
+    "@aws-cdk/aws-lambda": "^1.204.0",
     "@aws-cdk/aws-lambda-python-alpha": "^2.192.0-alpha.0",
-    "@aws-cdk/aws-s3": "^1.203.0",
-    "@aws-cdk/aws-s3-deployment": "^1.203.0",
-    "aws-cdk-lib": "^2.189.1",
-    "cdk-iot-core-certificates-v3": "^0.0.13",
-    "constructs": "^10.0.0"
+    "@aws-cdk/aws-s3": "^1.204.0",
+    "@aws-cdk/aws-s3-deployment": "^1.204.0",
+    "aws-cdk-lib": "^2.192.0",
+    "cdk-iot-core-certificates-v3": "^0.0.14",
+    "constructs": "^10.4.2"
   }
 }


### PR DESCRIPTION
…ha as it is not working now.

chore: update dependencies in package.json

- Bump @types/node from 22.7.9 to 22.15.3
- Upgrade aws-cdk from 2.1007.0 to 2.1012.0
- Update ts-jest from 29.2.5 to 29.3.2
- Upgrade typescript from ~5.6.3 to ~5.8.3
- Bump @aws-cdk/aws-apigateway from ^1.203.0 to ^1.204.0
- Upgrade @aws-cdk/aws-apprunner-alpha from ^2.189.1-alpha.0 to ^2.192.0-alpha.0
- Update @aws-cdk/aws-ecr-assets from ^1.203.0 to ^1.204.0
- Bump @aws-cdk/aws-iam from ^1.203.0 to ^1.204.0
- Upgrade @aws-cdk/aws-iot from ^1.203.0 to ^1.204.0
- Update @aws-cdk/aws-lambda from ^1.203.0 to ^1.204.0
- Upgrade @aws-cdk/aws-s3 from ^1.203.0 to ^1.204.0
- Update @aws-cdk/aws-s3-deployment from ^1.203.0 to ^1.204.0
- Upgrade aws-cdk-lib from ^2.189.1 to ^2.192.0
- Update cdk-iot-core-certificates-v3 from ^0.0.13 to ^0.0.14
- Bump constructs from ^10.0.0 to ^10.4.2